### PR TITLE
Fixes #11 adding locale for Expires HTTP header

### DIFF
--- a/TransloaditLib/assembly/AssemblyBuilder.m
+++ b/TransloaditLib/assembly/AssemblyBuilder.m
@@ -82,6 +82,7 @@
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
     NSTimeZone *timeZone = [NSTimeZone timeZoneWithName:@"UTC"];
     [dateFormatter setTimeZone:timeZone];
+    [dateFormatter setLocale:[[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormatter setDateFormat:@"yyyy/MM/dd HH:mm:ss+00:00"];
 
     [auth setObject:[dateFormatter stringFromDate:dateTime] forKey:@"expires"];


### PR DESCRIPTION
Preventing INVALID_AUTH_EXPIRES_PARAMETER and AUTH_EXPIRED errors.